### PR TITLE
chatd-client: UserIdentity CRUD and room identity listing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import find_packages, setup
@@ -18,6 +18,7 @@ setup(
             'rooms = wazo_chatd_client.commands.rooms:RoomCommand',
             'status = wazo_chatd_client.commands.status:StatusCommand',
             'user_presences = wazo_chatd_client.commands.user_presences:UserPresenceCommand',
+            'user_identities = wazo_chatd_client.commands.user_identities:UserIdentityCommand',
         ],
     },
 )

--- a/wazo_chatd_client/commands/rooms.py
+++ b/wazo_chatd_client/commands/rooms.py
@@ -37,13 +37,6 @@ class RoomCommand(BaseCommand):
         self.raise_from_response(r)
         return r.json()
 
-    def list_available_identities_from_user(self, room_uuid):
-        headers = self._get_headers()
-        url = f'{self.base_url}/{room_uuid}/identities'
-        r = self.session.get(url, headers=headers)
-        self.raise_from_response(r)
-        return r.json()
-
     def search_messages_from_user(self, **params):
         headers = self._get_headers()
         url = f'{self.base_url}/messages'

--- a/wazo_chatd_client/commands/rooms.py
+++ b/wazo_chatd_client/commands/rooms.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .helpers.base import BaseCommand
@@ -34,6 +34,13 @@ class RoomCommand(BaseCommand):
         headers = self._get_headers()
         url = f'{self.base_url}/{room_uuid}/messages'
         r = self.session.post(url, json=message_args, headers=headers)
+        self.raise_from_response(r)
+        return r.json()
+
+    def list_available_identities_from_user(self, room_uuid):
+        headers = self._get_headers()
+        url = f'{self.base_url}/{room_uuid}/identities'
+        r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r.json()
 

--- a/wazo_chatd_client/commands/user_identities.py
+++ b/wazo_chatd_client/commands/user_identities.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from .helpers.base import BaseCommand
+
+
+class UserIdentityCommand(BaseCommand):
+    resource = 'users'
+
+    def list(self, user_uuid, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{user_uuid}/identities'
+        r = self.session.get(url, headers=headers)
+        self.raise_from_response(r)
+        return r.json()
+
+    def get(self, user_uuid, identity_uuid, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{user_uuid}/identities/{identity_uuid}'
+        r = self.session.get(url, headers=headers)
+        self.raise_from_response(r)
+        return r.json()
+
+    def create(self, user_uuid, identity_args, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{user_uuid}/identities'
+        r = self.session.post(url, json=identity_args, headers=headers)
+        self.raise_from_response(r)
+        return r.json()
+
+    def update(self, user_uuid, identity_uuid, identity_args, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{user_uuid}/identities/{identity_uuid}'
+        r = self.session.put(url, json=identity_args, headers=headers)
+        self.raise_from_response(r)
+
+    def delete(self, user_uuid, identity_uuid, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{user_uuid}/identities/{identity_uuid}'
+        r = self.session.delete(url, headers=headers)
+        self.raise_from_response(r)

--- a/wazo_chatd_client/commands/user_identities.py
+++ b/wazo_chatd_client/commands/user_identities.py
@@ -14,12 +14,9 @@ class UserIdentityCommand(BaseCommand):
         self.raise_from_response(r)
         return r.json()
 
-    def list_from_user(self, room_uuid=None):
+    def list_from_user(self, **params):
         headers = self._get_headers()
         url = f'{self.base_url}/me/identities'
-        params = {}
-        if room_uuid:
-            params['room_uuid'] = str(room_uuid)
         r = self.session.get(url, headers=headers, params=params)
         self.raise_from_response(r)
         return r.json()
@@ -43,6 +40,7 @@ class UserIdentityCommand(BaseCommand):
         url = f'{self.base_url}/{user_uuid}/identities/{identity_uuid}'
         r = self.session.put(url, json=identity_args, headers=headers)
         self.raise_from_response(r)
+        return r.json()
 
     def delete(self, user_uuid, identity_uuid, tenant_uuid=None):
         headers = self._get_headers(tenant_uuid=tenant_uuid)

--- a/wazo_chatd_client/commands/user_identities.py
+++ b/wazo_chatd_client/commands/user_identities.py
@@ -14,6 +14,16 @@ class UserIdentityCommand(BaseCommand):
         self.raise_from_response(r)
         return r.json()
 
+    def list_from_user(self, room_uuid=None):
+        headers = self._get_headers()
+        url = f'{self.base_url}/me/identities'
+        params = {}
+        if room_uuid:
+            params['room_uuid'] = str(room_uuid)
+        r = self.session.get(url, headers=headers, params=params)
+        self.raise_from_response(r)
+        return r.json()
+
     def get(self, user_uuid, identity_uuid, tenant_uuid=None):
         headers = self._get_headers(tenant_uuid=tenant_uuid)
         url = f'{self.base_url}/{user_uuid}/identities/{identity_uuid}'


### PR DESCRIPTION
## Summary

Adds client commands needed by the wazo-chatd connectors plugin (multichannel SMS support, see wazo-chatd PR #193).

- `UserIdentityCommand` — CRUD for the new admin `/users/{user_uuid}/identities` endpoints (link an external identity like an SMS number to a user).
- `UserIdentityCommand.list_from_user(**params)` — lists the authenticated user's identities via `/users/me/identities`, accepting arbitrary query params (e.g. `room_uuid=...` to filter for "send as" options when composing a message in a room).

## Test plan

- [ ] Unit tests in wazo-chatd-client pass
- [ ] Used downstream by wazo-chatd PR #193 (REST contract round-trips end-to-end)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new client-side wrapper around REST endpoints with minimal impact on existing behavior, aside from exposing a new command entry point.
> 
> **Overview**
> Adds a new `UserIdentityCommand` (registered as `user_identities`) to perform list/get/create/update/delete operations against the `/users/{user_uuid}/identities` and `/users/me/identities` endpoints, including optional tenant scoping.
> 
> Minor housekeeping updates copyright headers in `setup.py` and `rooms.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 763805bfc45c63dc3d5bb14fe910366211970b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->