### PR TITLE
[ITEM-312] Add connector.auth_schema command

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,16 @@ client.rooms.search_messages_from_user(search='found')
 client.connectors.list(tenant_uuid=<tenant_uuid>)
 ```
 
-### List a connector's provider-reported inventory with binding state
+### List a connector's provider-reported identities with binding state
 
 ```python
-client.connectors.inventory(<backend>, tenant_uuid=<tenant_uuid>)
+client.connectors.identities(<backend>, tenant_uuid=<tenant_uuid>)
+```
+
+### Get a connector's credential schema
+
+```python
+client.connectors.auth_schema(<backend>, tenant_uuid=<tenant_uuid>)
 ```
 
 ### List all identities in the tenant

--- a/wazo_chatd_client/commands/connectors.py
+++ b/wazo_chatd_client/commands/connectors.py
@@ -19,3 +19,10 @@ class ConnectorCommand(BaseCommand):
         r = self.session.get(url, headers=headers)
         self.raise_from_response(r)
         return r.json()
+
+    def auth_schema(self, backend, tenant_uuid=None):
+        headers = self._get_headers(tenant_uuid=tenant_uuid)
+        url = f'{self.base_url}/{backend}/auth-schema'
+        r = self.session.get(url, headers=headers)
+        self.raise_from_response(r)
+        return r.json()


### PR DESCRIPTION
## What

Adds `client.connectors.auth_schema(<backend>, tenant_uuid=...)`, wrapping `GET /connectors/<backend>/auth-schema`. Returns the parsed credential schema (`scope` + `fields`), consistent with the other connector commands which return `r.json()` directly.

```python
schema = client.connectors.auth_schema('twilio', tenant_uuid=tenant_uuid)
# {'scope': 'tenant', 'fields': [{'name': 'api_key', 'type': 'secret', ...}, ...]}
```

## Notes

- Also fixes a stale README entry: `connectors.inventory(...)` was renamed to `connectors.identities()` but the doc wasn't updated.

## Server side

Pairs with the `GET /connectors/<backend>/auth-schema` endpoint in wazo-chatd (`feat/connector-auth-schema`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive client GET wrapper and documentation fixes with no auth or data-write behavior in this repo.
> 
> **Overview**
> Adds **`client.connectors.auth_schema(backend, tenant_uuid=...)`**, a read-only client for **`GET /connectors/<backend>/auth-schema`** so callers can fetch a connector’s credential schema (`scope` + `fields`) the same way other connector commands return **`r.json()`**.
> 
> The **README** is updated to document that call and to replace the stale **`connectors.inventory`** example with **`connectors.identities`**, matching the current API naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0453958105790d9352c44aa0d9b69db257e180a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->